### PR TITLE
Add userinfo.email scope

### DIFF
--- a/src/gkeClient.ts
+++ b/src/gkeClient.ts
@@ -63,7 +63,10 @@ export class ClusterClient {
     // This method looks for the GCLOUD_PROJECT and GOOGLE_APPLICATION_CREDENTIALS
     // environment variables.
     this.auth = new GoogleAuth({
-      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      scopes: [
+        'https://www.googleapis.com/auth/cloud-platform',
+        'https://www.googleapis.com/auth/userinfo.email',
+      ],
     });
     // Set credentials, if any.
     let jsonContent;


### PR DESCRIPTION
Allows GKE RBAC authentication using the provided service account's email instead of its ID.
Based on [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#forbidden_error_for_service_accounts_on_vm_instances) the token used for GKE authentication needs the `userinfo.email` scope for a ClusterRoleBinding with `User: service-accountl@project-.iam.gserviceaccount.com` to work, otherwise, the service account's unique ID is required.