### PR TITLE
Enable application default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,8 @@ See [usage](https://github.com/google-github-actions/auth#usage) for more detail
 
 If you are hosting your own runners, **and** those runners are on Google Cloud,
 you can leverage the Application Default Credentials of the instance. This will
-authenticate requests as the service account attached to the instance and requires
-`GCLOUD_PROJECT` environment variable to be set. **This only works using a custom
-runner hosted on GCP.**
+authenticate requests as the service account attached to the instance. **This
+only works using a custom runner hosted on GCP.**
 
 ```yaml
 - id: get-credentials

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 # get-gke-credentials
 
 This action configures authentication to a [GKE cluster][gke] via a `kubeconfig` file that can be used with `kubectl` or other methods of interacting with the cluster.
@@ -31,21 +32,21 @@ This action requires:
 
 ```yaml
 steps:
-- id: auth
-  uses: google-github-actions/auth@v0.4.0
-  with:
-    workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
-    service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+  - id: auth
+    uses: google-github-actions/auth@v0.4.0
+    with:
+      workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+      service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
 
-- id: get-credentials
-  uses: google-github-actions/get-gke-credentials@v0.3.0
-  with:
-    cluster_name: my-cluster
-    location: us-central1-a
+  - id: get-credentials
+    uses: google-github-actions/get-gke-credentials@v0.3.0
+    with:
+      cluster_name: my-cluster
+      location: us-central1-a
 
-# The KUBECONFIG env var is automatically exported and picked up by kubectl.
-- id: get-pods
-  run: kubectl get pods
+  # The KUBECONFIG env var is automatically exported and picked up by kubectl.
+  - id: get-pods
+    run: kubectl get pods
 ```
 
 ## Inputs
@@ -77,7 +78,7 @@ with **at least** the following roles:
 
 - Kubernetes Engine Cluster Viewer (`roles/container.clusterViewer`):
   - Get and list access to GKE Clusters.
-`
+    `
 
 ### Via google-github-actions/auth
 
@@ -119,8 +120,9 @@ See [usage](https://github.com/google-github-actions/auth#usage) for more detail
 
 If you are hosting your own runners, **and** those runners are on Google Cloud,
 you can leverage the Application Default Credentials of the instance. This will
-authenticate requests as the service account attached to the instance. **This
-only works using a custom runner hosted on GCP.**
+authenticate requests as the service account attached to the instance and requires
+`GCLOUD_PROJECT` environment variable to be set. **This only works using a custom
+runner hosted on GCP.**
 
 ```yaml
 - id: get-credentials

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
 # get-gke-credentials
 
 This action configures authentication to a [GKE cluster][gke] via a `kubeconfig` file that can be used with `kubectl` or other methods of interacting with the cluster.
@@ -32,21 +31,21 @@ This action requires:
 
 ```yaml
 steps:
-  - id: auth
-    uses: google-github-actions/auth@v0.4.0
-    with:
-      workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
-      service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+- id: auth
+  uses: google-github-actions/auth@v0.4.0
+  with:
+    workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+    service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
 
-  - id: get-credentials
-    uses: google-github-actions/get-gke-credentials@v0.3.0
-    with:
-      cluster_name: my-cluster
-      location: us-central1-a
+- id: get-credentials
+  uses: google-github-actions/get-gke-credentials@v0.3.0
+  with:
+    cluster_name: my-cluster
+    location: us-central1-a
 
-  # The KUBECONFIG env var is automatically exported and picked up by kubectl.
-  - id: get-pods
-    run: kubectl get pods
+# The KUBECONFIG env var is automatically exported and picked up by kubectl.
+- id: get-pods
+  run: kubectl get pods
 ```
 
 ## Inputs
@@ -78,7 +77,7 @@ with **at least** the following roles:
 
 - Kubernetes Engine Cluster Viewer (`roles/container.clusterViewer`):
   - Get and list access to GKE Clusters.
-    `
+`
 
 ### Via google-github-actions/auth
 

--- a/src/gkeClient.ts
+++ b/src/gkeClient.ts
@@ -60,8 +60,8 @@ export class ClusterClient {
     let projectId = opts?.projectId;
     if (
       !opts?.credentials &&
-      (!process.env.GCLOUD_PROJECT ||
-        !process.env.GOOGLE_APPLICATION_CREDENTIALS)
+      !process.env.GCLOUD_PROJECT &&
+      !process.env.GOOGLE_APPLICATION_CREDENTIALS
     ) {
       throw new Error(
         'No method for authentication. Set credentials in this action or export credentials from the setup-gcloud action',

--- a/src/gkeClient.ts
+++ b/src/gkeClient.ts
@@ -58,11 +58,7 @@ export class ClusterClient {
 
   constructor(location: string, opts?: ClientOptions) {
     let projectId = opts?.projectId;
-    if (
-      !opts?.credentials &&
-      !process.env.GCLOUD_PROJECT &&
-      !process.env.GOOGLE_APPLICATION_CREDENTIALS
-    ) {
+    if (!opts?.credentials) {
       throw new Error(
         'No method for authentication. Set credentials in this action or export credentials from the setup-gcloud action',
       );


### PR DESCRIPTION
When running on self-hosted GCE VMs providing the action with only `cluster_name` and `location`, it fails with `No method for authentication` because the constructor expects both `GCLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables to be set.
This PR allows the constructor to proceed if one of `GCLOUD_PROJECT`, `GOOGLE_APPLICATION_CREDENTIALS` or `opts.credentials` is set, and adds the `GCLOUD_PROJECT` environment variable configuration to the README example.

I'm not sure how to add an integration test for this though, since it would require a GCP hosted runner.