### PR TITLE
Fix #290 - Set kubeconfig_path output

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
   debug as logDebug,
   info as logInfo,
   setFailed,
+  setOutput,
 } from '@actions/core';
 import {
   errorMessage,
@@ -139,6 +140,7 @@ async function run(): Promise<void> {
 
       exportVariable('KUBECONFIG', kubeConfigPath);
       exportVariable('KUBE_CONFIG_PATH', kubeConfigPath);
+      setOutput('kubeconfig_path', kubeConfigPath);
       logInfo(`Successfully created and exported "KUBECONFIG" at: ${kubeConfigPath}`);
     } catch (err) {
       const msg = errorMessage(err);


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
Set the `kubeconfig_path` output as described in the documentation. 

Fixes #290.