### PR TITLE
update client.ts to include new accessToken auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ jobs:
         location: 'us-central1-a'
 ```
 
+#### Authenticating via Service Account static access token
+
+```yaml
+jobs:
+  job_id:
+    steps:
+    - id: 'get-credentials'
+      uses: 'google-github-actions/get-gke-credentials@v2'
+      env:
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      with:
+        cluster_name: 'my-cluster'
+        location: 'us-central1-a'
+```
+
 #### Authenticating via Service Account Key JSON
 
 ```yaml

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,6 +155,11 @@ export class ClusterClient {
     this.#location = opts?.location;
   }
 
+    /**
+   * Retrieves the auth client for authenticating requests.
+   *
+   * @returns string
+   */
   async getToken(): Promise<string> {
     // Check if the access token is provided via environment variables
     const envToken = process.env.ACCESS_TOKEN;

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,7 @@ import { presence } from '@google-github-actions/actions-utils';
 import { GoogleAuth } from 'google-auth-library';
 import { Headers } from 'gaxios';
 import YAML from 'yaml';
+import { debug as logDebug } from '@actions/core';
 
 // Do not listen to the linter - this can NOT be rewritten as an ES6 import statement.
 const { version: appVersion } = require('../package.json');
@@ -154,16 +155,20 @@ export class ClusterClient {
     this.#location = opts?.location;
   }
 
-  /**
-   * Retrieves the auth client for authenticating requests.
-   *
-   * @returns string
-   */
   async getToken(): Promise<string> {
+    // Check if the access token is provided via environment variables
+    const envToken = process.env.ACCESS_TOKEN;
+    if (envToken) {
+      logDebug(`Going with Env, ${envToken}`);
+      return envToken;
+    }
+
+    // Fallback to the original functionality
     const token = await this.auth.getAccessToken();
     if (!token) {
       throw new Error('Failed to generate token.');
     }
+    logDebug(`Going with fetch token`);
     return token;
   }
 


### PR DESCRIPTION
A PR not generated via AI to explain what's going on with this PR:

Rules of engagement:
- Removing suspicious lines from previous [PR](https://github.com/google-github-actions/get-gke-credentials/pull/319)
- Cleaning self-intentions with holy water since Google's OSS representative can read minds and block me
- Removing AI-generated descriptions to avoid getting blocked as well
- Keep compiling the JS for the maintainers

**What's changed:**

1. Adding support to pass access tokens explicitly to override the host's identity 
2. Added logging into `client.ts` to check which path the code toke at execution

**Why?**

A use case can be to impersonate an SA dynamically and pass that impersonated SA short-lived token in the kubeconf to reach specific GKEs only.

**benefits:**

- It will provide more dynamicity, especially in self-hosted runners
- Increase security to allow specific users to access specific GKEs
- Avoid WIF if not needed